### PR TITLE
chore(pkg): rename binary command from branch-name-lint to git-branch…

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	"type": "module",
 	"main": "bin/index.js",
 	"bin": {
-		"branch-name-lint": "./bin/index.js"
+		"git-branch-lint": "./bin/index.js"
 	},
 	"files": [
 		"bin"


### PR DESCRIPTION
…-lint

Updated the binary command name in package.json to better reflect the package's purpose and align with the project name.